### PR TITLE
Fix for HLS download

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -427,7 +427,7 @@ function downloadHLS($filepath) {
     $filepath = escapeshellcmd($filepath);
     $outputpath = escapeshellcmd($outputpath);
     if(true || !file_exists($outputpath)){
-        $command = "ffmpeg -allowed_extensions ALL -y -i {$filepath} -c copy {$outputpath}";
+        $command = "ffmpeg -allowed_extensions ALL -y -i {$filepath} -c:v copy -bsf:a aac_adtstoasc -strict -2 {$outputpath}";
         //var_dump($outputfilename, $command, $_GET, $filepath, $quoted);exit;
         exec($command . " 2>&1", $output, $return);
         if(!empty($return)){

--- a/functions.php
+++ b/functions.php
@@ -427,7 +427,7 @@ function downloadHLS($filepath) {
     $filepath = escapeshellcmd($filepath);
     $outputpath = escapeshellcmd($outputpath);
     if(true || !file_exists($outputpath)){
-        $command = "ffmpeg -allowed_extensions ALL -y -i {$filepath} -c:v copy -bsf:a aac_adtstoasc -strict -2 {$outputpath}";
+        $command = "ffmpeg -allowed_extensions ALL -y -i {$filepath} -c:v copy -c:a copy -bsf:a aac_adtstoasc -strict -2 {$outputpath}";
         //var_dump($outputfilename, $command, $_GET, $filepath, $quoted);exit;
         exec($command . " 2>&1", $output, $return);
         if(!empty($return)){


### PR DESCRIPTION
You can't copy hls into mp4 with `-c copy` 
`-bsf:a aac_adtstoasc` is required
`aac` audio codec is experimental , so `-strict` -2 is required